### PR TITLE
fix: peer deps cannot resolve dep error for react 18

### DIFF
--- a/sgds-masthead-react/package.json
+++ b/sgds-masthead-react/package.json
@@ -33,8 +33,8 @@
     "@govtechsg/sgds-masthead": "^0.0.10"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": ">=17.0.2",
+    "react-dom": ">=17.0.2"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
Fix for the following error when trying to install sgds-masthead-react on react 18.  


![Screenshot 2022-05-25 at 2 35 29 PM](https://user-images.githubusercontent.com/55618945/170196093-6e0ccd23-4340-4a4d-b188-7d75b95918ad.png)
